### PR TITLE
Add `bitwuzla`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,6 +34,23 @@
         "type": "github"
       }
     },
+    "bitwuzla_unstable_2021_07_01": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1625171294,
+        "narHash": "sha256-BPAa/SMxDzspQl+RaonMyq6N36o5mIBCWj36e5vG1Rs=",
+        "owner": "bitwuzla",
+        "repo": "bitwuzla",
+        "rev": "58d720598e359b1fdfec4a469c76f1d1f24db51a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitwuzla",
+        "repo": "bitwuzla",
+        "rev": "58d720598e359b1fdfec4a469c76f1d1f24db51a",
+        "type": "github"
+      }
+    },
     "boolector_src_3_1_0": {
       "flake": false,
       "locked": {
@@ -171,6 +188,7 @@
       "inputs": {
         "abc_src_2020_06_22": "abc_src_2020_06_22",
         "abc_src_2021_12_30": "abc_src_2021_12_30",
+        "bitwuzla_unstable_2021_07_01": "bitwuzla_unstable_2021_07_01",
         "boolector_src_3_1_0": "boolector_src_3_1_0",
         "boolector_src_3_2_0": "boolector_src_3_2_0",
         "boolector_src_3_2_1": "boolector_src_3_2_1",

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,10 @@
       url = "github:berkeley-abc/abc/48498af";
       flake = false;
     };
+    bitwuzla_unstable_2021_07_01 = {
+      url = "github:bitwuzla/bitwuzla/58d720598e359b1fdfec4a469c76f1d1f24db51a";
+      flake = false;
+    };
     boolector_src_3_2_2 = {
       url = "github:boolector/boolector/3.2.2";
       flake = false;
@@ -127,6 +131,7 @@
               inherit version;
               src = inps."${"abc_src_" + version}";
             });
+          mkBitwuzla = mkVerPkg "bitwuzla";
           mkBoolector = mkVerPkg "boolector";
           mkCVC4 = mkVerPkg "cvc4";
           mkYices = mkVerPkg "yices";
@@ -166,6 +171,9 @@
             v1_7   = mkCVC4 "1.7";
             v4_1_8   = mkCVC4 "1.8";
             v4_1_7   = mkCVC4 "1.7";
+          };
+          bitwuzla = pkgs.bitwuzla // { # whatever the nixpkgs current version is...
+            vunstable_2021_07_01 = mkBitwuzla "unstable-2021-07-01";
           };
           boolector = pkgs.boolector // { # whatever the nixpkgs current version is...
             v3_2   = mkBoolector "3.2.2";


### PR DESCRIPTION
Nixpkgs currently contains `bitwuzla-unstable-2021-07-01`, so add it here. This will likely be useful for things like GaloisInc/what4#124.