### PR TITLE
Updated nixos from 21.11 to 22.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,16 +187,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638239011,
-        "narHash": "sha256-AjhmbT4UBlJWqxY0ea8a6GU2C2HdKUREkG43oRr3TZg=",
+        "lastModified": 1653936696,
+        "narHash": "sha256-M6bJShji9AIDZ7Kh7CPwPBPb/T7RiVev2PAcOi4fxDQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31",
+        "rev": "ce6aa13369b667ac2542593170993504932eb836",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "21.11",
+        "ref": "22.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
   #   $ nix run github:GaloisInc/flakes#z3.v4_8_14 -- -version
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/21.11";
+    nixpkgs.url = "github:nixos/nixpkgs/22.05";
     flake-utils.url = "github:numtide/flake-utils";
     abc_src_2020_06_22 = {
       url = "github:berkeley-abc/abc/341db2566";


### PR DESCRIPTION
22.05 is the first version of nixos that recognizes cvc5