### PR TITLE
CVC5: Configure with `--cocoa`

### DIFF
--- a/cocoalib/0.99800/CoCoALib-0.99800-trace.patch
+++ b/cocoalib/0.99800/CoCoALib-0.99800-trace.patch
@@ -1,0 +1,254 @@
+diff --git a/configuration/cxx14.sh b/configuration/cxx14.sh
+index a5472cd..2a3e608 100755
+--- a/configuration/cxx14.sh
++++ b/configuration/cxx14.sh
+@@ -51,7 +51,7 @@ int main() {
+ EOF
+ 
+ # First try with no compiler flag...
+-"$CXX"  language-version.C  -o language-version  >> LogFile  2>& 1 
++"$CXX" $CXXFLAGS language-version.C  -o language-version  >> LogFile  2>& 1 
+ if [ $? -ne 0 ]
+ then
+     echo "ERROR: compilation unexpectedly failed; is $CXX a c++ compiler?   $SCRIPT_NAME" > /dev/stderr
+@@ -74,7 +74,7 @@ fi
+ # Compilation without flag is not C++14 standard; try with -std=c++14
+ 
+ CXX14="-std=c++14"
+-"$CXX"  $CXX14  language-version.C  -o language-version  >> LogFile  2>& 1 
++"$CXX" $CXXFLAGS  $CXX14  language-version.C  -o language-version  >> LogFile  2>& 1 
+ if [ $? -ne 0 ]
+ then
+     echo "ERROR: compilation with flag $CXX14 failed   $SCRIPT_NAME" > /dev/stderr
+diff --git a/configuration/gmp-version.sh b/configuration/gmp-version.sh
+index ebd85c7..5693280 100755
+--- a/configuration/gmp-version.sh
++++ b/configuration/gmp-version.sh
+@@ -73,7 +73,7 @@ int main()
+ EOF
+ 
+ # Use c++ compiler specified in CXX; no need to specify libgmp as all info is in header file!!
+-$CXX -I"$COCOA_EXTLIB_DIR/include"  test-gmp-version.C  -o test-gmp-version  > LogFile 2>&1
++$CXX $CXXFLAGS -I"$COCOA_EXTLIB_DIR/include"  test-gmp-version.C  -o test-gmp-version  > LogFile 2>&1
+ 
+ # Check whether compilation failed; if so, complain.
+ if [ $? -ne 0 ]
+diff --git a/configuration/verify-compiler.sh b/configuration/verify-compiler.sh
+index 7a70933..c752e34 100755
+--- a/configuration/verify-compiler.sh
++++ b/configuration/verify-compiler.sh
+@@ -55,15 +55,6 @@ int main()
+ }
+ EOF
+ 
+-# Try plain compiler (without CXXFLAGS):
+-$CXX test-compiler-gnu.C -o test-compiler-gnu  > LogFile  2>&1
+-if [ $? -ne 0 -o \! -f test-compiler-gnu -o \! -x test-compiler-gnu ]
+-then
+-  echo "ERROR: Are you sure \"$CXX\" is a C++ compiler?   $SCRIPT_NAME"  > /dev/stderr
+-  exit 1
+-fi
+-/bin/rm test-compiler-gnu  # not necessary, just being tidy :-)
+-
+ # Try compiler with CXXFLAGS:
+ $CXX $CXXFLAGS test-compiler-gnu.C -o test-compiler-gnu  > LogFile  2>&1
+ if [ $? -ne 0 -o \! -f test-compiler-gnu -o \! -x test-compiler-gnu ]
+diff --git a/configuration/shell-fns.sh b/configuration/shell-fns.sh
+index 190dbb4..c8d281f 100755
+--- a/configuration/shell-fns.sh
++++ b/configuration/shell-fns.sh
+@@ -11,7 +11,7 @@ mktempdir()
+ {
+     TODAY=`date "+%Y%m%d"`
+     TIME=`date "+%H%M%S"`
+-    TMP_DIR="/tmp/CoCoALib-config/$USER-$TODAY/$1-$TIME-$$"
++    TMP_DIR="/tmp/CoCoALib-config-$USER/$USER-$TODAY/$1-$TIME-$$"
+     /bin/rm -rf "$TMP_DIR"  &&  /bin/mkdir -p "$TMP_DIR"
+     if [ $? -ne 0 ]
+     then
+@@ -25,22 +25,22 @@ echounderline()
+ echounderline()
+ {
+   echo "$*"
+-  echo "$*" | tr "\040-\377" "[-*]"
++  echo "$*" | tr "\040-\377" "-"
+ }
+
+ echobox()
+ {
+   mesg=">>>>  $*  <<<<"
+-  dashes=`echo "$mesg" | tr "\040-\377" "[-*]"`
++  dashes=`echo "$mesg" | tr "\040-\377" "-"`
+   echo "$dashes"
+   echo "$mesg"
+   echo "$dashes"
+ }
+
+ echoerror()
+ {
+   mesg=">>>>>  $*  <<<<<"
+-  equals=`echo "$mesg" | tr "\040-\377" "[=*]"`
++  equals=`echo "$mesg" | tr "\040-\377" "="`
+   echo "$equals"
+   echo "$mesg"
+   echo "$equals"
+diff --git a/include/CoCoA/TmpGPoly.H b/include/CoCoA/TmpGPoly.H
+index 4c4d51e..efe50f7 100644
+--- a/include/CoCoA/TmpGPoly.H
++++ b/include/CoCoA/TmpGPoly.H
+@@ -29,6 +29,7 @@
+ #include "CoCoA/TmpGTypes.H"
+ #include "CoCoA/utils.H"
+ 
++#include<functional>
+ #include<list>
+ // using std::list; // for GPolyList; GPolyPtrList;
+ #include<vector>
+@@ -46,6 +47,11 @@ enum ClearMarker {clear};
+ 
+ class GPoly;
+ 
++extern bool handlersEnabled;
++extern std::function<void(ConstRefRingElem p, ConstRefRingElem q, ConstRefRingElem s)> sPolyHandler;
++extern std::function<void(ConstRefRingElem p)> reductionStartHandler;
++extern std::function<void(ConstRefRingElem q)> reductionStepHandler;
++extern std::function<void(ConstRefRingElem r)> reductionEndHandler;
+ 
+ typedef std::list<GPoly> GPolyList;
+ 
+diff --git a/src/AlgebraicCore/PolyRing-content.C b/src/AlgebraicCore/PolyRing-content.C
+index c5d0a0a..36d6d2b 100644
+--- a/src/AlgebraicCore/PolyRing-content.C
++++ b/src/AlgebraicCore/PolyRing-content.C
+@@ -33,6 +33,7 @@
+ #include "CoCoA/convert.H"
+ #include "CoCoA/error.H"
+ #include "CoCoA/utils.H"  // for len
++#include "CoCoA/TmpGPoly.H"
+ 
+ 
+ #include <vector>
+@@ -128,7 +129,9 @@ namespace CoCoA
+   {
+     const PolyRing Rx = owner(f);
+     RingElem ans(Rx);
++    if (handlersEnabled) reductionStartHandler(f);
+     Rx->myMonic(raw(ans), raw(f));
++    if (handlersEnabled) reductionEndHandler(ans);
+     return ans;
+   }
+ 
+diff --git a/src/AlgebraicCore/SparsePolyOps-reduce.C b/src/AlgebraicCore/SparsePolyOps-reduce.C
+index b5b8b43..11687f0 100644
+--- a/src/AlgebraicCore/SparsePolyOps-reduce.C
++++ b/src/AlgebraicCore/SparsePolyOps-reduce.C
+@@ -134,6 +134,7 @@ degree HereForProfilingOnlyWDeg(ConstRefPPMonoidElem cofactor1)
+       v.myGRingInfo().myCheckForTimeout("ReduceActiveLM");
+       s->myUpdate(F, *g);
+       F->myReduce(poly(*g), NumTerms(*g));
++      if ( handlersEnabled ) reductionStepHandler(poly(*g));
+     }//while
+   }//ReduceActiveLM
+ 
+@@ -269,6 +270,7 @@ degree HereForProfilingOnlyWDeg(ConstRefPPMonoidElem cofactor1)
+   void GPoly::myReduce(const Reductors& theReductors)
+   {
+     if ( IsZero(*this) ) return;
++    if ( handlersEnabled ) reductionStartHandler(myPoly());
+     ReductionCog F = ChooseReductionCogGeobucket(myGRingInfo());
+     F->myAssignReset(myPolyValue, myNumTerms); // myPolyValue gets 0
+     reduce(F, mySugar, theReductors); // mySugar updated
+@@ -278,6 +280,7 @@ degree HereForProfilingOnlyWDeg(ConstRefPPMonoidElem cofactor1)
+     if ( !IsZero(*this) && !IsOne(myLCValue) ) // makes myPolyValue monic
+       if ( myGRingInfo().myCoeffRingType()==CoeffEncoding::Field )
+         myGRingInfo().myNewSPR()->myDivByCoeff(raw(myPolyValue), raw(myLCValue));
++    if ( handlersEnabled ) reductionEndHandler(myPoly());
+     // if CoeffEncoding::Field myRelease does NOT make poly monic
+     // if CoeffEncoding::FrFldOfGCDDomain myRelease makes poly content free
+   }
+diff --git a/src/AlgebraicCore/TmpGPoly.C b/src/AlgebraicCore/TmpGPoly.C
+index ea250d4..3447d86 100644
+--- a/src/AlgebraicCore/TmpGPoly.C
++++ b/src/AlgebraicCore/TmpGPoly.C
+@@ -47,6 +47,11 @@ using std::vector;
+ namespace CoCoA
+ {  
+ 
++  bool handlersEnabled = false;
++  std::function<void(ConstRefRingElem p, ConstRefRingElem q, ConstRefRingElem s)> sPolyHandler = nullptr;
++  std::function<void(ConstRefRingElem p)> reductionStartHandler = nullptr;
++  std::function<void(ConstRefRingElem q)> reductionStepHandler = nullptr;
++  std::function<void(ConstRefRingElem r)> reductionEndHandler = nullptr;
+ 
+   //---------class GPoly-------------------------------
+ 
+@@ -301,7 +306,10 @@ void GPoly::myUpdateLenLPPLCDegComp()
+     if (the_gp.IsInputPoly())
+       myPolyValue = poly(the_gp.myFirstGPoly());
+     else
++    {
+       myPolySetSPoly(the_gp.myFirstGPoly(), the_gp.mySecondGPoly());
++      if ( handlersEnabled ) sPolyHandler(the_gp.myFirstGPoly().myPoly(), the_gp.mySecondGPoly().myPoly(), myPoly());
++    }
+     myUpdateLenLPPLCDegComp();
+     myAge = the_age;
+     // MAX: do these things only if necessary.
+diff --git a/configuration/gmp-check-cxxflags.sh b/configuration/gmp-check-cxxflags.sh
+index f34c10d..6c167a3 100755
+--- a/configuration/gmp-check-cxxflags.sh
++++ b/configuration/gmp-check-cxxflags.sh
+@@ -59,7 +59,7 @@ fi
+ 
+ 
+ GMP_LDLIB=-lgmp
+-if [ -f "$COCOA_EXTLIB_DIR"/lib/libgmp-symlink.a ]
++if [ -f "$COCOA_EXTLIB_DIR"/lib/libgmp-symlink."$GMP_LIB_EXTN" ]
+ then
+   GMP_LDLIB=-lgmp-symlink
+ fi
+diff --git a/configure b/configure
+index 769750d..5ac5e90 100755
+--- a/configure
++++ b/configure
+@@ -336,6 +336,7 @@ fi
+ # Next two lines required by the scripts which check GMP (see below).
+ export CXX
+ export CXXFLAGS
++export GMP_LIB_EXTN
+ 
+ # Check compiler and flags are sane.
+ # If all is well, result is either "gnu" or "not gnu" & return code is 0.
+@@ -467,6 +468,7 @@ else
+       # gmp-find.sh script worked, so message is full path of GMP library
+       /bin/ln -s "$GMP_MESG" $EXTLIBS/lib/libgmp-symlink.a
+       GMP_LIB="$GMP_MESG"
++      GMP_LIB_EXTN="a"
+     fi
+   fi
+ fi
+diff --git a/include/CoCoA/MakeUnifiedHeader.sh b/include/CoCoA/MakeUnifiedHeader.sh
+index 1111111..2222222 100755
+--- a/include/CoCoA/MakeUnifiedHeader.sh
++++ b/include/CoCoA/MakeUnifiedHeader.sh
+@@ -33,7 +33,7 @@ echobox()
+ echobox()
+ {
+   mesg=">>>>  $*  <<<<"
+-  dashes=`echo "$mesg" | tr "\040-\377" "[-*]"`
++  dashes=`echo "$mesg" | tr "\040-\377" "-"`
+   echo "$dashes"
+   echo "$mesg"
+   echo "$dashes"
+diff --git a/src/AlgebraicCore/CheckSourceFiles.sh b/src/AlgebraicCore/CheckSourceFiles.sh
+index 3333333..4444444 100755
+--- a/src/AlgebraicCore/CheckSourceFiles.sh
++++ b/src/AlgebraicCore/CheckSourceFiles.sh
+@@ -24,7 +24,7 @@ done
+ done
+ sort "$TMPFILE2" > "$TMPFILE1"
+
+-/bin/ls -d ./*.C | cut -b 3- > "$TMPFILE2"
++/bin/ls -d ./*.C | cut -b 3- | sort > "$TMPFILE2"
+
+ cmp "$TMPFILE1" "$TMPFILE2" > /dev/null
+ if [ $? = 0 ]

--- a/cocoalib/0.99800/default.nix
+++ b/cocoalib/0.99800/default.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  coreutils,
+  diffutils,
+  gmp,
+  pkg-config,
+  which,
+}:
+
+let
+  gmp-static = gmp.override { withStatic = true; };
+in
+stdenv.mkDerivation rec {
+  name = "cocoalib";
+  version = "0.99800";
+
+  src = fetchurl {
+    url = "https://github.com/cvc5/cvc5-deps/blob/main/CoCoALib-0.99800.tgz";
+    hash = "sha256-+Lsifi4XKeFxz3rCAIr3HfJZFGB3EsNdt7y1oESpKMY=";
+  };
+
+  patches = [
+    # Adapted from https://github.com/cocoa-official/CoCoALib/pull/90
+    ./pkgconfig.patch
+    # Taken from CVC5:
+    # https://github.com/cvc5/cvc5/blob/6f9eb83f0bfa10929519045730bec47c70c16967/cmake/deps-utils/CoCoALib-0.99800-trace.patch
+    ./CoCoALib-0.99800-trace.patch
+  ];
+
+  buildInputs = [ gmp-static ];
+
+  nativeBuildInputs = [
+    pkg-config
+    which
+  ];
+
+  postPatch = ''
+    SCRIPTS_TO_PATCH="$(find . -name '*.sh' -print)"
+    MAKEFILES_TO_PATCH="$(find . -name 'Makefile' -print)"
+    patchShebangs configure $SCRIPTS_TO_PATCH
+    for file in configure $SCRIPTS_TO_PATCH $MAKEFILES_TO_PATCH; do
+      substituteInPlace "$file" \
+        --replace /bin/cat ${coreutils}/bin/cat \
+        --replace /bin/cp ${coreutils}/bin/cp \
+        --replace /bin/mkdir ${coreutils}/bin/mkdir \
+        --replace /bin/ln ${coreutils}/bin/ln \
+        --replace /bin/ls ${coreutils}/bin/ls \
+        --replace /bin/mv ${coreutils}/bin/mv \
+        --replace /bin/rm ${coreutils}/bin/rm \
+        --replace /usr/bin/cmp ${diffutils}/bin/cmp
+    done
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+    mkdir -p $out/include
+    mkdir -p $out/lib
+    ./configure --prefix=$out --with-libgmp=${gmp-static.out}/lib/libgmp.a
+    runHook postConfigure
+  '';
+
+  meta = {
+    description = "Computations in Commutative Algebra";
+    homepage    = "https://cocoa.altervista.org/cocoalib/index.shtml";
+    license     = lib.licenses.gpl3;
+    platforms   = lib.platforms.unix;
+  };
+}

--- a/cocoalib/0.99800/default.nix
+++ b/cocoalib/0.99800/default.nix
@@ -53,12 +53,9 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  configurePhase = ''
-    runHook preConfigure
+  preConfigure = ''
     mkdir -p $out/include
     mkdir -p $out/lib
-    ./configure --prefix=$out --with-libgmp=${gmp-static.out}/lib/libgmp.a
-    runHook postConfigure
   '';
 
   meta = {

--- a/cocoalib/0.99800/default.nix
+++ b/cocoalib/0.99800/default.nix
@@ -9,9 +9,6 @@
   which,
 }:
 
-let
-  gmp-static = gmp.override { withStatic = true; };
-in
 stdenv.mkDerivation rec {
   name = "cocoalib";
   version = "0.99800";
@@ -29,7 +26,7 @@ stdenv.mkDerivation rec {
     ./CoCoALib-0.99800-trace.patch
   ];
 
-  buildInputs = [ gmp-static ];
+  buildInputs = [ gmp ];
 
   nativeBuildInputs = [
     pkg-config

--- a/cocoalib/0.99800/default.nix
+++ b/cocoalib/0.99800/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   version = "0.99800";
 
   src = fetchurl {
-    url = "https://github.com/cvc5/cvc5-deps/blob/main/CoCoALib-0.99800.tgz";
+    url = "https://cocoa.altervista.org/cocoalib/tgz/CoCoALib-0.99800.tgz";
     hash = "sha256-+Lsifi4XKeFxz3rCAIr3HfJZFGB3EsNdt7y1oESpKMY=";
   };
 

--- a/cocoalib/0.99800/pkgconfig.patch
+++ b/cocoalib/0.99800/pkgconfig.patch
@@ -1,0 +1,58 @@
+diff --git a/configuration/gmp-find-hdr.sh b/configuration/gmp-find-hdr.sh
+index b86abb5..2a17081 100755
+--- a/configuration/gmp-find-hdr.sh
++++ b/configuration/gmp-find-hdr.sh
+@@ -31,20 +31,24 @@ then
+   GMP_INC_DIR="$GMP_LIB_DIR_DIR"
+ else
+   # GMP is installed -- have to check two possible locations for the header file
+-  GMP_INC_DIR1="$GMP_LIB_DIR_DIR"/include
+-  GMP_INC_DIR2="$GMP_LIB_DIR_DIR_DIR/include"
+-  GMP_INC_DIR3="$GMP_LIB_DIR_DIR_DIR/include/$PLATFORM"
+-  if [ -f "$GMP_INC_DIR1/gmp.h" ]
++  GMP_INC_DIR1="$(pkg-config --variable=includedir gmp 2>/dev/null)"
++  GMP_INC_DIR2="$GMP_LIB_DIR_DIR"/include
++  GMP_INC_DIR3="$GMP_LIB_DIR_DIR_DIR/include"
++  GMP_INC_DIR4="$GMP_LIB_DIR_DIR_DIR/include/$PLATFORM"
++  if [ -n "$GMP_INC_DIR1" ] && [ -f "$GMP_INC_DIR1/gmp.h" ]
+   then
+     GMP_INC_DIR="$GMP_INC_DIR1"
+   elif [ -f "$GMP_INC_DIR2/gmp.h" ]
+   then
+     GMP_INC_DIR="$GMP_INC_DIR2"
+-  elif [ -n "$PLATFORM" -a -f "$GMP_INC_DIR3/gmp.h" ]
++  elif [ -f "$GMP_INC_DIR3/gmp.h" ]
+   then
+     GMP_INC_DIR="$GMP_INC_DIR3"
++  elif [ -n "$PLATFORM" ] && [ -f "$GMP_INC_DIR4/gmp.h" ]
++  then
++    GMP_INC_DIR="$GMP_INC_DIR4"
+   else
+-    echo "ERROR: Cannot find GMP header for $GMP_LIB; searched in $GMP_INC_DIR1 and $GMP_INC_DIR2 and $GMP_INC_DIR3   $SCRIPT_NAME"   > /dev/stderr
++    echo "ERROR: Cannot find GMP header for $GMP_LIB; searched in $GMP_INC_DIR1 and $GMP_INC_DIR2 and $GMP_INC_DIR3 and $GMP_INC_DIR4   $SCRIPT_NAME"   > /dev/stderr
+     exit 3
+   fi
+ fi
+diff --git a/configuration/gmp-find.sh b/configuration/gmp-find.sh
+index 744fc78..37bd110 100755
+--- a/configuration/gmp-find.sh
++++ b/configuration/gmp-find.sh
+@@ -13,7 +13,17 @@ SCRIPT_NAME=[[`basename "$0"`]]
+ # NB look through all directories, even if a GMP has already been found.
+ 
+ # List of directories under which libgmp.a and/or libgmp.so is normally found.
+-STD_GMP_LIBDIRS="/usr/lib  /usr/lib/x86_64-linux-gnu  /usr/lib/i386-linux-gnu  /usr/lib64  /usr/lib32  /usr/local/lib  /opt/local/lib  /sw/lib  /usr/sfw/lib"
++
++
++STD_GMP_LIBDIRS="/usr/local/lib  /usr/lib  /usr/lib/$ARCH-linux-gnu  /usr/lib64
++                 /usr/lib32  /usr/lib/i386-linux-gnu  /opt/homebrew/lib
++                 /opt/local/lib  /sw/lib  /usr/sfw/lib"
++
++# Also try pkg-config
++if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists gmp; then
++    STD_GMP_LIBDIRS="$(pkg-config --variable=libdir gmp 2>/dev/null) $STD_GMP_LIBDIRS"
++fi
++
+ # # Some versions of Linux put libgmp.a in an immediate subdirectory of /usr/lib/
+ # for file in /usr/lib/*
+ # do

--- a/flake.lock
+++ b/flake.lock
@@ -542,6 +542,19 @@
         "url": "https://crates.io/api/v1/crates/cloudabi/0.0.3/download"
       }
     },
+    "cocoalib-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648225889,
+        "narHash": "sha256-HKphJKSYXXyYlrP8ZfEs5rXmB7K4DYD0qJo8nLQvuyQ=",
+        "type": "tarball",
+        "url": "https://cocoa.altervista.org/cocoalib/tgz/CoCoALib-0.99800.tgz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://cocoa.altervista.org/cocoalib/tgz/CoCoALib-0.99800.tgz"
+      }
+    },
     "colorchoice-src": {
       "flake": false,
       "locked": {
@@ -1379,6 +1392,7 @@
         "boolector_src_3_2_2": "boolector_src_3_2_2",
         "boolector_src_3_2_3": "boolector_src_3_2_3",
         "build-bom": "build-bom",
+        "cocoalib-src": "cocoalib-src",
         "cvc4_src_1_7": "cvc4_src_1_7",
         "cvc4_src_1_8": "cvc4_src_1_8",
         "cvc5_src_1_0_0": "cvc5_src_1_0_0",

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,10 @@
     build-bom = {
       url = "github:GaloisInc/flakes?dir=build-bom";
     };
+    cocoalib-src = {
+      url = "https://cocoa.altervista.org/cocoalib/tgz/CoCoALib-0.99800.tgz";
+      flake = false;
+    };
     cvc4_src_1_8 = {
       url = "github:cvc4/cvc4/1.8";
       flake = false;
@@ -230,7 +234,10 @@
               inherit version;
               src = inps."${pkg + "_src_" + cleanVer version}";
             });
-          cocoalib = pkgs.callPackage "${self}/cocoalib/0.99800" {};
+          cocoalib = (pkgs.callPackage "${self}/cocoalib/0.99800" {}).overrideAttrs (_: {
+            src = inps.cocoalib-src;
+            version = "0.99800";
+          });
           mkABC = version:
             pkgs.abc-verifier.overrideAttrs (_: {
               name = "abc";

--- a/flake.nix
+++ b/flake.nix
@@ -230,6 +230,7 @@
               inherit version;
               src = inps."${pkg + "_src_" + cleanVer version}";
             });
+          cocoalib = pkgs.callPackage "${self}/cocoalib/0.99800" {};
           mkABC = version:
             pkgs.abc-verifier.overrideAttrs (_: {
               name = "abc";
@@ -256,7 +257,12 @@
               # configureFlags = old.configureFlags ++ [ "--symfpu" ];
               cmakeFlags = (old.cmakeFlags or []) ++ [ "-DUSE_SYMFPU=ON" ];
             });
-          mkCVC5 = mkVerPkg "cvc5";
+          mkCVC5 = version:
+            let basePkg = mkVerPkg "cvc5" version;
+            in basePkg.overrideAttrs (old: {
+              buildInputs = old.buildInputs ++ [ cocoalib ];
+              cmakeFlags = (old.cmakeFlags or []) ++ [ "-DUSE_COCOA=ON" "-DENABLE_GPL=ON" ];
+            });
           mk22CVC5 = mkVerPkg22 "cvc5";
           mkYices = mkVerPkg "yices";
           mk22Yices = mkVerPkg22 "yices";


### PR DESCRIPTION
This requires that CVC5 build against CoCoALib, which is unfortunately not yet available in `nixpkgs` (https://github.com/NixOS/nixpkgs/issues/323885). This adds a `default.nix` file for CoCoALib 0.99800 so that CVC5 can build against it in a Nix-y way. Unfortunately, CoCoALib's build system is _not_ very Nix-y, as it makes lots of hard-coded assumptions about where dependencies live (e.g., assuming that `mv` lives at `/bin/mv` in particular). I needed to heavily patch CoCoALib's source code in order to make it Nix-friendly.

Fixes #10.